### PR TITLE
fix drop zone

### DIFF
--- a/packages/otfjs-ui/src/components/font-context.tsx
+++ b/packages/otfjs-ui/src/components/font-context.tsx
@@ -9,7 +9,7 @@ import { Font } from 'otfjs'
 
 import { HasChildren } from '../types/has-children'
 import { noop } from '../utils/noop'
-import { fetchFont } from '../utils/fetch-font'
+import { fetchFont, loadFont } from '../utils/fetch-font'
 
 interface FontContextValue {
   font: Font | null
@@ -59,6 +59,20 @@ export function useFetchFont() {
   return useCallback(async (url: string) => {
     try {
       const font = await fetchFont(url)
+      setFont(font)
+    } catch (e) {
+      // TODO: some kind of toast on failure?
+      console.error('Failed to load font', e)
+    }
+  }, [])
+}
+
+export function useLoadFont() {
+  const setFont = useSetFont()
+
+  return useCallback(async (data: Uint8Array) => {
+    try {
+      const font = await loadFont(data)
       setFont(font)
     } catch (e) {
       // TODO: some kind of toast on failure?

--- a/packages/otfjs-ui/src/components/full-screen-drop-zone/full-screen-drop-zone.tsx
+++ b/packages/otfjs-ui/src/components/full-screen-drop-zone/full-screen-drop-zone.tsx
@@ -2,10 +2,10 @@ import { useRef, useState } from 'react'
 
 import { HasChildren } from '../../types/has-children'
 import { preventDefault } from '../../utils/event'
-import { useFetchFont } from '../font-context'
+import { useLoadFont } from '../font-context'
 
 export function FullScreenDropZone({ children }: HasChildren) {
-  const loadFont = useFetchFont()
+  const loadFont = useLoadFont()
   const [dragover, setDragover] = useState(false)
   const enterCount = useRef(0)
 
@@ -20,12 +20,15 @@ export function FullScreenDropZone({ children }: HasChildren) {
       onDragLeave={() => {
         if (--enterCount.current === 0) setDragover(false)
       }}
-      onDrop={(e) => {
+      onDrop={async (e) => {
+        e.preventDefault()
+
         enterCount.current = 0
         setDragover(false)
 
-        e.preventDefault()
-        void e.dataTransfer.files[0].arrayBuffer().then(loadFont)
+        const buffer = await e.dataTransfer.files[0].arrayBuffer()
+        const data = new Uint8Array(buffer)
+        await loadFont(data)
       }}
     >
       {children}

--- a/packages/otfjs-ui/src/components/full-screen-drop-zone/full-screen-drop-zone.tsx
+++ b/packages/otfjs-ui/src/components/full-screen-drop-zone/full-screen-drop-zone.tsx
@@ -26,8 +26,7 @@ export function FullScreenDropZone({ children }: HasChildren) {
         enterCount.current = 0
         setDragover(false)
 
-        const buffer = await e.dataTransfer.files[0].arrayBuffer()
-        const data = new Uint8Array(buffer)
+        const data = await e.dataTransfer.files[0].bytes()
         await loadFont(data)
       }}
     >

--- a/packages/otfjs-ui/src/main.tsx
+++ b/packages/otfjs-ui/src/main.tsx
@@ -1,3 +1,5 @@
+import './polyfill'
+
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 

--- a/packages/otfjs-ui/src/polyfill.ts
+++ b/packages/otfjs-ui/src/polyfill.ts
@@ -1,0 +1,8 @@
+async function bytes(this: Blob | Request | Response): Promise<Uint8Array> {
+  return new Uint8Array(await this.arrayBuffer())
+}
+
+for (const C of ['Blob', 'Request', 'Response']) {
+  const p = (globalThis as any)[C]?.prototype
+  if (p && !p.bytes) p.bytes = bytes
+}

--- a/packages/otfjs-ui/src/utils/fetch-font.ts
+++ b/packages/otfjs-ui/src/utils/fetch-font.ts
@@ -11,19 +11,22 @@ export async function fetchFont(fontUrl: string) {
   let fontPromise = CACHE.get(fontUrl)
 
   if (!fontPromise) {
-    fontPromise = loadFont(fontUrl)
+    fontPromise = fetchFontInternal(fontUrl)
     CACHE.set(fontUrl, fontPromise)
   }
 
   return fontPromise
 }
 
-async function loadFont(fontUrl: string) {
+async function fetchFontInternal(fontUrl: string) {
   const req = await fetch(fontUrl)
   const data = new Uint8Array(await req.arrayBuffer())
+  return loadFont(data)
+}
+
+export async function loadFont(data: Uint8Array) {
   const font = await readFont(data)
   await loadFontForUse(font)
-
   return font
 }
 

--- a/packages/otfjs-ui/src/utils/fetch-font.ts
+++ b/packages/otfjs-ui/src/utils/fetch-font.ts
@@ -20,7 +20,7 @@ export async function fetchFont(fontUrl: string) {
 
 async function fetchFontInternal(fontUrl: string) {
   const req = await fetch(fontUrl)
-  const data = new Uint8Array(await req.arrayBuffer())
+  const data = await req.bytes()
   return loadFont(data)
 }
 


### PR DESCRIPTION
drop zone was broken after some refactor. splitting hooks up into one that can load from url, and one that can load from array buffer